### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JMDict #
 
 JMDict is a simple library written in Go for parsing the raw data files for the
-[JMDict](http://www.edrdg.org/enamdict/enamdict_doc.html) (vocabulary)
+[JMDict](http://www.edrdg.org/jmdict/j_jmdict.html) (vocabulary)
 [JMnedict](http://www.edrdg.org/enamdict/enamdict_doc.html) (names), and
 [KANJIDIC](http://nihongo.monash.edu/kanjidic2/index.html) (Kanji) dictionaries. As far as I know, these are the only
 publicly available Japanese dictionaries and are therefore used by a variety of tools (including


### PR DESCRIPTION
JMDict link was pointing the proper names dictionary, was probably just a copy-paste error